### PR TITLE
Add Hydra argparse doc

### DIFF
--- a/conf/run_qwen3_235B_A22B.yaml
+++ b/conf/run_qwen3_235B_A22B.yaml
@@ -1,0 +1,144 @@
+base_folder: ${oc.env:BASE_FOLDER}
+
+model_args:
+  - --disable-bias-linear
+  - --qk-layernorm
+  - --group-query-attention
+  - --num-attention-heads 64
+  - --num-query-groups 4
+  - --kv-channels 128
+  - --num-layers 94
+  - --hidden-size 4096
+  - --ffn-hidden-size 12288
+  - --normalization RMSNorm
+  - --position-embedding-type rope
+  - --norm-epsilon 1e-6
+  - --rotary-percent 1.0
+  - --swiglu
+  - --untie-embeddings-and-output-weights
+  - --vocab-size 151936
+  - --rotary-base 1000000
+  - --moe-ffn-hidden-size 1536
+  - --moe-router-score-function softmax
+  - --moe-token-dispatcher-type alltoall
+  - --moe-router-topk 8
+  - --moe-layer-freq "'([1]*94)'"
+  - --num-experts 128
+  - --moe-grouped-gemm
+  - --moe-token-drop-policy probs
+  - --moe-router-dtype fp32
+  - --moe-permute-fusion
+  - --moe-aux-loss-coeff 0
+
+ckpt_args:
+  - --hf-checkpoint ${base_folder}/Qwen3-235B-A22B
+  - --ref-load ${base_folder}/Qwen3-235B-A22B_torch_dist
+  - --load ${base_folder}/Qwen3-235B-A22B_slime/
+  - --save ${base_folder}/Qwen3-235B-A22B_slime/
+  - --save-interval 20
+
+rollout_args:
+  - --prompt-data ${base_folder}/dapo-math-17k/dapo-math-17k.jsonl
+  - --input-key prompt
+  - --label-key label
+  - --apply-chat-template
+  - --rollout-shuffle
+  - --rm-type deepscaler
+  - --num-rollout 3000
+  - --rollout-batch-size 8
+  - --n-samples-per-prompt 8
+  - --rollout-max-response-len 8192
+  - --rollout-temperature 0.8
+  - --global-batch-size 64
+  - --balance-data
+
+eval_args:
+  - --eval-prompt-data aime ${base_folder}/aime-2024/aime-2024.jsonl
+  - --n-samples-per-eval-prompt 16
+  - --eval-max-response-len 16384
+  - --eval-top-p 0.7
+
+perf_args:
+  - --tensor-model-parallel-size 4
+  - --sequence-parallel
+  - --pipeline-model-parallel-size 4
+  - --context-parallel-size 2
+  - --expert-model-parallel-size 8
+  - --expert-tensor-parallel-size 1
+  - --decoder-last-pipeline-num-layers 22
+  - --recompute-granularity full
+  - --recompute-method uniform
+  - --recompute-num-layers 1
+  - --use-dynamic-batch-size
+  - --max-tokens-per-gpu 4096
+
+grpo_args:
+  - --advantage-estimator grpo
+  - --kl-loss-coef 0.00
+  - --kl-loss-type low_var_kl
+  - --entropy-coef 0.00
+  - --eps-clip 0.2
+  - --eps-clip-high 0.28
+
+optimizer_args:
+  - --optimizer adam
+  - --lr 1e-6
+  - --lr-decay-style constant
+  - --weight-decay 0.1
+  - --adam-beta1 0.9
+  - --adam-beta2 0.98
+  - --optimizer-cpu-offload
+  - --overlap-cpu-optimizer-d2h-h2d
+  - --use-precision-aware-optimizer
+
+wandb_args: []
+
+sglang_args:
+  - --rollout-num-gpus-per-engine 32
+  - --sglang-mem-fraction-static 0.5
+  - --sglang-enable-ep-moe
+  - --sglang-enable-dp-attention
+  - --sglang-dp-size 4
+  - --sglang-cuda-graph-bs
+  - 1
+  - 2
+  - 4
+  - 8
+  - 16
+  - 24
+  - 32
+  - 40
+  - 48
+  - 56
+  - 64
+  - 72
+  - 80
+  - 88
+  - 96
+  - 104
+  - 112
+  - 120
+  - 128
+  - 136
+  - 144
+  - 152
+  - 160
+  - 168
+  - 176
+  - 184
+  - 192
+  - 200
+  - 208
+  - 216
+  - 224
+  - 232
+  - 240
+  - 248
+  - 256
+
+misc_args:
+  - --attention-dropout 0.0
+  - --hidden-dropout 0.0
+  - --accumulate-allreduce-grads-in-fp32
+  - --attention-softmax-in-fp32
+  - --attention-backend flash

--- a/docs/en/hydra_argparse.md
+++ b/docs/en/hydra_argparse.md
@@ -81,6 +81,17 @@ ray job submit --address="http://127.0.0.1:8265" \
 ```
 
 The script sources `scripts/models/deepseek-v3.sh` to load model settings, assembles argument arrays, and finally invokes `train.py` via a Ray job. `train.py` parses all options, forwarding generic ones to Megatron and the `--sglang-*` subset to the inference engine. This allows training and inference to launch together from one script.
+## 5. Driving bash scripts with Hydra
+
+Sometimes we prefer not to change the existing shell framework at all. You can keep `scripts/run-qwen3-235B-A22B.sh` untouched and use Hydra only to build the argument arrays it expects. A sample config lives in `conf/run_qwen3_235B_A22B.yaml`. Generate the arrays with:
+
+```bash
+python3 tools/generate_args.py --config-name run_qwen3_235B_A22B > args.sh
+source args.sh
+```
+
+The helper prints variables like `CKPT_ARGS=( ... )`. Once sourced, the original script can be executed normally and receives the same arguments as before.
+
 
 ---
 

--- a/docs/zh/hydra_argparse.md
+++ b/docs/zh/hydra_argparse.md
@@ -81,6 +81,17 @@ ray job submit --address="http://127.0.0.1:8265" \
    ${SGLANG_ARGS[@]} \
    ${MISC_ARGS[@]}
 ```
+## 5. 使用 Hydra 生成 Shell 参数
+
+如果希望完全保持现有脚本不变，可以让 Hydra 仅负责生成诸如 `CKPT_ARGS` 的参数数组。示例配置见 `conf/run_qwen3_235B_A22B.yaml`，使用方式如下：
+
+```bash
+python3 tools/generate_args.py --config-name run_qwen3_235B_A22B > args.sh
+source args.sh
+```
+
+该脚本会输出诸如 `CKPT_ARGS=( ... )` 的变量，source 后即可正常执行原来的启动脚本。
+
 
 脚本首先从 `scripts/models/deepseek-v3.sh` 读取模型配置，再按类别组装参数数组，最终通过 Ray 启动 `train.py`。`train.py` 解析这些参数后，将普通参数传给 Megatron 训练逻辑，将带有 `--sglang-` 的参数用于构建推理引擎。由此实现单脚本同时启动训练与推理。
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 accelerate
 httpx[http2]
+hydra-core
 mcp[cli]
 pylatexenc
 ray[default]

--- a/tools/generate_args.py
+++ b/tools/generate_args.py
@@ -1,0 +1,22 @@
+import shlex
+from typing import Sequence
+
+from hydra import compose, initialize
+
+
+def format_args(name: str, args: Sequence[str]) -> str:
+    quoted = " ".join(shlex.quote(str(a)) for a in args)
+    return f"{name}=(\n  {quoted}\n)"
+
+
+def main():
+    with initialize(config_path="../conf", job_name="generate_args", version_base=None):
+        cfg = compose(config_name="run_qwen3_235B_A22B")
+
+    for key, value in cfg.items():
+        if isinstance(value, list):
+            print(format_args(key.upper(), value))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document integration between Hydra and argparse
- cover parameter routing for sglang and Megatron
- show how DeepSeek-v3 RL script forwards args

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68885c089700832cabecb1b31c731e05