### PR TITLE
Implement optional rank2rank MoE weight sync

### DIFF
--- a/slime/backends/megatron_utils/update_weight_utils.py
+++ b/slime/backends/megatron_utils/update_weight_utils.py
@@ -342,6 +342,9 @@ class UpdateWeightFromDistributed:
         pp_rank = mpu.get_pipeline_model_parallel_rank()
         if self._is_pp_src_rank:
             self._group_name = f"slime-pp_{pp_rank}"
+        self._rank2rank_enabled = getattr(self.args, "enable_moe_rank2rank_sync", False)
+        self._ep_rank = mpu.get_expert_model_parallel_rank()
+        self._ep_size = mpu.get_expert_model_parallel_world_size()
 
         if self._is_pp_src_rank:
             master_address = ray._private.services.get_node_ip_address()
@@ -369,6 +372,29 @@ class UpdateWeightFromDistributed:
                 group_name=self._group_name,
             )
             ray.get(refs)
+
+            if self._rank2rank_enabled:
+                r2r_world = self.args.rollout_num_gpus + 1
+                r2r_group_name = f"{self._group_name}-r2r_{self._ep_rank}"
+                r2r_refs = [
+                    engine.init_process_group.remote(
+                        master_address,
+                        master_port,
+                        1 + i * self.args.rollout_num_gpus_per_engine,
+                        r2r_world,
+                        r2r_group_name,
+                        backend="nccl",
+                    )
+                    for i, engine in enumerate(self.rollout_engines)
+                ]
+                self._r2r_group = init_process_group(
+                    backend="nccl",
+                    init_method=f"tcp://{master_address}:{master_port}",
+                    world_size=r2r_world,
+                    rank=0,
+                    group_name=r2r_group_name,
+                )
+                ray.get(r2r_refs)
 
     def update_weights(self):
         if dist.get_rank() == 0:
@@ -440,6 +466,12 @@ class UpdateWeightFromDistributed:
         return buffer_size
 
     def _update_expert_bucket_weights_from_distributed(self, named_tensors, pbar=None):
+        if self._rank2rank_enabled:
+            if not self._is_pp_src_rank:
+                named_tensors.clear()
+                return
+            return self._update_expert_bucket_weights_rank2rank(named_tensors, pbar=pbar)
+
         names = [name for name, _ in named_tensors]
         all_names = [None] * mpu.get_expert_model_parallel_world_size()
         dist.all_gather_object(all_names, names, group=mpu.get_expert_model_parallel_group())
@@ -470,6 +502,36 @@ class UpdateWeightFromDistributed:
         for name, param in all_gathered_params:
             converted_hf_tensors += convert_to_hf(self.args, self.model_name, name, param, self.quantization_config)
         self._update_bucket_weights_from_distributed(converted_hf_tensors, pbar=pbar)
+
+    def _update_expert_bucket_weights_rank2rank(self, named_tensors, pbar=None):
+        names = [name for name, _ in named_tensors]
+        refs = [
+            engine.update_weights_from_distributed_rank2rank.remote(
+                names=names,
+                dtypes=[param.dtype for _, param in named_tensors],
+                shapes=[param.shape for _, param in named_tensors],
+                group_name=f"{self._group_name}-r2r_{self._ep_rank}",
+            )
+            for engine in self.rollout_engines
+        ]
+
+        handles = []
+        for _, param in named_tensors:
+            handles.append(
+                dist.broadcast(
+                    param.data,
+                    0,
+                    group=self._r2r_group,
+                    async_op=True,
+                )
+            )
+        for handle in handles:
+            handle.wait()
+
+        ray.get(refs)
+        named_tensors.clear()
+        if pbar is not None:
+            pbar.update(1)
 
     def _update_bucket_weights_from_distributed(self, converted_named_tensors, pbar=None):
         # lock the rollout engines to prevent dead lock on broadcast.

--- a/slime/backends/sglang_utils/http_server_engine.py
+++ b/slime/backends/sglang_utils/http_server_engine.py
@@ -168,6 +168,18 @@ class HttpServerEngineAdapter:
             },
         )
 
+    def update_weights_from_distributed_rank2rank(self, names, dtypes, shapes, group_name, flush_cache=False):
+        return self._make_request(
+            "update_weights_from_distributed_rank2rank",
+            {
+                "names": names,
+                "dtypes": [str(dtype).replace("torch.", "") for dtype in dtypes],
+                "shapes": shapes,
+                "group_name": group_name,
+                "flush_cache": flush_cache,
+            },
+        )
+
     def pause_generation(self):
         return requests.post(f"http://{self.server_args.host}:{self.server_args.port}/pause_generation", json={})
 

--- a/slime/backends/sglang_utils/sglang_engine.py
+++ b/slime/backends/sglang_utils/sglang_engine.py
@@ -80,6 +80,10 @@ class SglangEngine:
         self.llm.update_weights_from_distributed(names, dtypes, shapes, group_name)
         return
 
+    def update_weights_from_distributed_rank2rank(self, names, dtypes, shapes, group_name):
+        self.llm.update_weights_from_distributed_rank2rank(names, dtypes, shapes, group_name)
+        return
+
     def update_weights_from_tensor(self, ipc_handles):
         self.llm.update_weights_from_tensor(ipc_handles)
         return

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -277,6 +277,11 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 help="Interval for updating the weights",
             )
             parser.add_argument(
+                "--enable-moe-rank2rank-sync",
+                action="store_true",
+                help="Enable rank-to-rank MoE weight synchronization",
+            )
+            parser.add_argument(
                 "--keep-old-actor",
                 action="store_true",
                 help="Whether to keep the rollout model on training process",


### PR DESCRIPTION
## Summary
- add `--enable-moe-rank2rank-sync` cli argument
- set up extra NCCL groups when enabled for direct EP-to-engine broadcasts
- expose new HTTP helpers `update_weights_from_distributed_rank2rank`
- refine group construction to create per-expert groups and broadcast from rank 0

## Testing
- `pre-commit run --files slime/backends/megatron_utils/update_weight_utils.py slime/backends/sglang_utils/http_server_engine.py slime/backends/sglang_utils/sglang_engine.py slime/utils/arguments.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b2c9dce48832cba2ee673e557848b